### PR TITLE
Add Slackin URL and widget

### DIFF
--- a/_includes/themes/rubyrockers/default.html
+++ b/_includes/themes/rubyrockers/default.html
@@ -29,6 +29,9 @@
                 allowtransparency="true" frameborder="0" scrolling="0" width="95px" height="20px">
               </iframe>
           </div>
+          <div>
+            <script async defer src="https://ruby-rockers.herokuapp.com/slackin.js"></script>
+          </div>
           <div class="twitter-follow" style="margin-bottom: 20px;">
             <a href="https://twitter.com/{{ site.author.twitter }}" class="twitter-follow-button" data-show-count="false" data-lang="en"></a>
           </div>
@@ -44,6 +47,7 @@
         <li><a target="_blank" href="http://github.com/{{ site.author.github }}/">Github</a>
         <li><a target="_blank" href="http://twitter.com/{{ site.author.twitter }}/">Twitter</a>
         <li><a target="_blank" href="irc://irc.freenode.net/{{ site.author.irc }}">IRC</a>
+        <li><a target="_blank" href="https://ruby-rockers.herokuapp.com/">Slack</a>
       </ul>
       </nav>
 

--- a/index.md
+++ b/index.md
@@ -10,8 +10,6 @@ layout : page
       <header><h2>when</h2></header>
       <p>
         Third saturday of every month, 11.00AM. 
-        
-        The most recent meetup was on <a href="http://gathers.us/events/bangalore-ruby-user-group-april-meet">20th of April 2013</a>, and the meetup notes <a href="/meetups.html" target="_blank">are here</a>.
       </p>
     </article>
   


### PR DESCRIPTION
The slackin app (hosted at https://ruby-rockers.herokuapp.com/) by
@raysrashmi allows users to request for Slack invite and also shows
the number of live users.