### PR TITLE
Remove 'Members', s/Group/Mailing list in nav

### DIFF
--- a/_includes/themes/rubyrockers/default.html
+++ b/_includes/themes/rubyrockers/default.html
@@ -42,8 +42,7 @@
       <nav class='links'>
       <ul>
         <li><a target="_blank" href="http://www.meetup.com/Bangalore-Ruby-Users-Group/">Meetups</a></li>
-        <li><a target="_blank" href="http://www.meetup.com/Bangalore-Ruby-Users-Group/members/">Members</a></li>
-        <li><a target="_blank" href="https://groups.google.com/forum/?fromgroups#!forum/{{ site.author.google_group }}/">Group</a>
+        <li><a target="_blank" href="https://groups.google.com/forum/?fromgroups#!forum/{{ site.author.google_group }}/">Mailing list</a>
         <li><a target="_blank" href="http://github.com/{{ site.author.github }}/">Github</a>
         <li><a target="_blank" href="http://twitter.com/{{ site.author.twitter }}/">Twitter</a>
         <li><a target="_blank" href="irc://irc.freenode.net/{{ site.author.irc }}">IRC</a>


### PR DESCRIPTION
Joining the meetup page is not the criteria for anyone to be a member of BRUG. Actually there is no official "membership" required to take part in any of the BRUG activities. So I think it's best to remove the "Members" link. Also, "Group" was too generic a name, "Mailing list" suits better, imo. @swanandp please review and merge.

Closes #20 