### PR TITLE
Grammatical fix to one of the lines on the homepage of bangaloreruby

### DIFF
--- a/_includes/themes/rubyrockers/default.html
+++ b/_includes/themes/rubyrockers/default.html
@@ -53,7 +53,7 @@
       <section id="container">
       <div id="flash">
       </div>
-      <h5>Be sure to follow <a href="http://twitter.com/bangaloreruby" target="_blanl">@bangaloreruby</a> for everything Ruby in Bangalore.</h5>
+      <h5>Be sure to follow <a href="http://twitter.com/bangaloreruby" target="_blanl">@bangaloreruby</a> for everything about Ruby in Bangalore.</h5>
       {{ content }}
       </section>
       <section id="sidebar">


### PR DESCRIPTION
The [homepage](http://bangaloreruby.org/) line with respect to which the change is made is given below -

`Be sure to follow @bangaloreruby for everything Ruby in Bangalore.`